### PR TITLE
Add fs-verity support to /rootfs partition

### DIFF
--- a/features/redpesk-partitioning.ks
+++ b/features/redpesk-partitioning.ks
@@ -8,6 +8,10 @@ part /data  	--fstype ext4 --size 500                --label=data     --fsoption
 
 %post --nochroot --logfile=/mnt/sysroot/tmp/post-fstab.log --erroronfail
 
+echo "Adapting rootfs partition to support verity features..."
+PART=$(blkid /dev/mapper/Redpesk-OS* | grep "LABEL=.rootfs" | cut -f1 -d:)
+tune2fs -O verity $PART
+
 echo "Setting UUID into /etc/fstab..."
 grep "^/dev.*Redpesk*" /mnt/sysroot/etc/fstab | while read part ; do
 	dev=$(echo $part | cut -d' ' -f1)


### PR DESCRIPTION
Necessary to have FS_IOC_ENABLE_VERITY for ext4 filesystem. Not possible for anaconda to read verity partitions when mounting or unmounting them so it's necessary to do this operation in %post outside the chroot build environment.